### PR TITLE
Updated Docker configuration for Pluto 0.12

### DIFF
--- a/docker/default/Dockerfile
+++ b/docker/default/Dockerfile
@@ -12,9 +12,8 @@ RUN useradd -m -d ${USER_HOME_DIR} ${USER} \
 COPY prestartup.jl ${USER_HOME_DIR}/
 COPY startup.jl ${USER_HOME_DIR}/
 
-RUN julia ${USER_HOME_DIR}/prestartup.jl
-
-RUN chown -R ${USER} ${USER_HOME_DIR}
+RUN julia ${USER_HOME_DIR}/prestartup.jl \
+    && chown -R ${USER} ${USER_HOME_DIR}
 USER ${USER}
 
 EXPOSE 1234

--- a/docker/default/prestartup.jl
+++ b/docker/default/prestartup.jl
@@ -1,2 +1,3 @@
 using Pkg
-Pkg.add(["Pluto", "PlutoUI", "Plots"]) # "Images", "ImageIO", "ImageMagick"])
+Pkg.add(["Pluto", "PlutoUI", "Plots"])
+Pkg.precompile()

--- a/docker/default/startup.jl
+++ b/docker/default/startup.jl
@@ -1,2 +1,5 @@
+versioninfo()
 using Pluto
-Pluto.run("0.0.0.0", 1234; configuration=Pluto.ServerConfiguration(launch_browser=false), security=Pluto.ServerSecurity(false))
+server_options = Pluto.Configuration.ServerOptions(; host="0.0.0.0", port=1234, launch_browser=false)
+security_options = Pluto.Configuration.SecurityOptions(; require_secret_for_access=false)
+Pluto.run(Pluto.Configuration.Options(; server=server_options, security=security_options))

--- a/docker/default/startup.jl
+++ b/docker/default/startup.jl
@@ -1,4 +1,3 @@
-versioninfo()
 using Pluto
 server_options = Pluto.Configuration.ServerOptions(; host="0.0.0.0", port=1234, launch_browser=false)
 security_options = Pluto.Configuration.SecurityOptions(; require_secret_for_access=false)

--- a/docker/precompiled/Dockerfile
+++ b/docker/precompiled/Dockerfile
@@ -34,9 +34,8 @@ COPY prestartup.jl ${USER_HOME_DIR}/
 COPY startup.jl ${USER_HOME_DIR}/
 
 COPY --from=builder /usr/local/julia/lib/julia/sys.so /usr/local/julia/lib/julia/sys.so
-RUN julia prestartup.jl
-
-RUN chown -R ${USER} ${USER_HOME_DIR}
+RUN julia prestartup.jl \
+    && chown -R ${USER} ${USER_HOME_DIR}
 USER ${USER}
 
 EXPOSE 1234

--- a/docker/precompiled/prestartup.jl
+++ b/docker/precompiled/prestartup.jl
@@ -1,3 +1,3 @@
 using Pkg
-Pkg.add(["Pluto", "PlutoUI", "Plots"]) # "Images", "ImageIO", "ImageMagick"])
+Pkg.add(["Pluto", "PlutoUI", "Plots"])
 Pkg.precompile()

--- a/docker/precompiled/prestartup.jl
+++ b/docker/precompiled/prestartup.jl
@@ -1,2 +1,3 @@
 using Pkg
 Pkg.add(["Pluto", "PlutoUI", "Plots"]) # "Images", "ImageIO", "ImageMagick"])
+Pkg.precompile()

--- a/docker/precompiled/startup.jl
+++ b/docker/precompiled/startup.jl
@@ -1,2 +1,5 @@
+versioninfo()
 using Pluto
-Pluto.run("0.0.0.0", 1234; configuration=Pluto.ServerConfiguration(launch_browser=false), security=Pluto.ServerSecurity(false))
+server_options = Pluto.Configuration.ServerOptions(; host="0.0.0.0", port=1234, launch_browser=false)
+security_options = Pluto.Configuration.SecurityOptions(; require_secret_for_access=false)
+Pluto.run(Pluto.Configuration.Options(; server=server_options, security=security_options))

--- a/docker/precompiled/startup.jl
+++ b/docker/precompiled/startup.jl
@@ -1,4 +1,3 @@
-versioninfo()
 using Pluto
 server_options = Pluto.Configuration.ServerOptions(; host="0.0.0.0", port=1234, launch_browser=false)
 security_options = Pluto.Configuration.SecurityOptions(; require_secret_for_access=false)

--- a/docker/precompiled/warmup.jl
+++ b/docker/precompiled/warmup.jl
@@ -3,6 +3,8 @@
 import Pluto
 
 session = Pluto.ServerSession()
+session.options.server.port = 40404
+session.options.security.require_secret_for_access = false
 
 path = tempname()
 original = joinpath(pathof(Pluto) |> dirname |> dirname, "sample", "Tower of Hanoi.jl")
@@ -20,7 +22,7 @@ Pluto.update_save_run!(session, nb, nb.cells; run_async=false, prerender_text=tr
 
 @info "Starting HTTP server"
 # next, we'll run the HTTP server which needs a bit of nasty code
-t = @async Pluto.run(40404; session=session)
+t = @async Pluto.run(session)
 
 sleep(5)
 download("http://localhost:40404/")


### PR DESCRIPTION
The changes in the Pluto config management required some modifications in the startup files.

```
security_options = Pluto.Configuration.SecurityOptions(; require_secret_for_access=false)
```
I have not switched off `require_secret_for_open_links` for now, but I am not sure if this is the best configuration for Docker.
What do you think?