### PR TITLE
K8s

### DIFF
--- a/k8s/nginx-controller.yaml
+++ b/k8s/nginx-controller.yaml
@@ -277,6 +277,11 @@ kind: Service
 metadata:
   annotations:
     service.beta.kubernetes.io/do-loadbalancer-enable-proxy-protocol: 'true'
+    service.beta.kubernetes.io/do-loadbalancer-protocol: "http"
+    service.beta.kubernetes.io/do-loadbalancer-algorithm: "round_robin"
+    service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-type: "cookies"
+    service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-name: "same-node-please"
+    service.beta.kubernetes.io/do-loadbalancer-sticky-sessions-cookie-ttl: "60"
   labels:
     helm.sh/chart: ingress-nginx-2.11.1
     app.kubernetes.io/name: ingress-nginx

--- a/k8s/pluto-deployment.yaml
+++ b/k8s/pluto-deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: pluto
 spec:
-  replicas: 4
+  replicas: 2
   selector:
     matchLabels:
       app: pluto
@@ -14,6 +14,16 @@ spec:
       labels:
         app: pluto
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: app
+                operator: In
+                values:
+                - pluto
+            topologyKey: "kubernetes.io/hostname"
       containers:
       - name: pluto-latest
         image: registry.digitalocean.com/pluto-docker-images/pluto

--- a/k8s/pluto-ingress.yaml
+++ b/k8s/pluto-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
-  name: pluto-test-ingress
+  name: pluto-ingress
   annotations:
     nginx.ingress.kubernetes.io/affinity: "cookie"
     nginx.ingress.kubernetes.io/session-cookie-name: "route"

--- a/k8s/pluto-ingress.yaml
+++ b/k8s/pluto-ingress.yaml
@@ -3,9 +3,16 @@ kind: Ingress
 metadata:
   name: pluto-test-ingress
   annotations:
-    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/affinity: "cookie"
+    nginx.ingress.kubernetes.io/session-cookie-name: "route"
+    nginx.ingress.kubernetes.io/session-cookie-expires: "60"
+    nginx.ingress.kubernetes.io/session-cookie-max-age: "60"
 spec:
-  backend:
-    serviceName: pluto-service
-    servicePort: 80
+  rules:
+  - host: margo.plutojl.org
+    http:
+      paths:
+      - backend:
+          serviceName: pluto-service
+          servicePort: 80
+        path: /

--- a/k8s/pluto-service.yaml
+++ b/k8s/pluto-service.yaml
@@ -3,6 +3,11 @@ kind: Service
 metadata:
   name: pluto-service
 spec:
+  clusterIP: "None"
+  sessionAffinity: "ClientIP"
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 300
   selector:
     app: pluto
   ports:


### PR DESCRIPTION
- Makes sure pods are not co-located in a node (anti-affinity)
- prevent ingress to service load balancing for 60 seconds
- make Pluto Service have get node by client IP


Note: needs to test that load ic actually being balanced 