### PR TITLE
Static export, adding more kwargs

### DIFF
--- a/src/Export.jl
+++ b/src/Export.jl
@@ -86,8 +86,6 @@ function export_paths(notebook_paths::Vector{String}; export_dir=".", output_dir
             end
 
             mkpath(output_dir)
-            @show output_dir
-            @show isdir(output_dir)
             export_path = joinpath(output_dir, basename(html_filename))
             export_jl_path = joinpath(export_dir, path)
 

--- a/src/Export.jl
+++ b/src/Export.jl
@@ -14,7 +14,7 @@ get(ENV, "GITHUB_ACTIONS", "false") == "true" && global_logger(GitHubActionsLogg
 
 myhash = base64encode ∘ sha256
 
-function github_action(; export_dir=".", offer_binder=false, copy_to_temp_before_running=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing)
+function github_action(; export_dir=".", output_dir=".", generate_default_index=false, offer_binder=false, copy_to_temp_before_running=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing)
     mkpath(export_dir)
 
     jlfiles = vcat(map(walkdir(".")) do (root, dirs, files)
@@ -29,9 +29,9 @@ function github_action(; export_dir=".", offer_binder=false, copy_to_temp_before
     notebookfiles = filter(jlfiles) do f
         readline(f) == "### A Pluto.jl notebook ###"
     end
-    export_paths(notebookfiles; export_dir=export_dir, copy_to_temp_before_running=copy_to_temp_before_running, offer_binder=offer_binder, disable_ui=disable_ui, bind_server_url=bind_server_url, binder_url=binder_url)
+    export_paths(notebookfiles; export_dir=export_dir, output_dir=output_dir, copy_to_temp_before_running=copy_to_temp_before_running, offer_binder=offer_binder, disable_ui=disable_ui, bind_server_url=bind_server_url, binder_url=binder_url)
 
-    create_default_index(;export_dir=export_dir)
+    generate_default_index && create_default_index(;export_dir=export_dir)
 end
 
 function create_default_index(;export_dir=".")
@@ -59,7 +59,7 @@ function create_default_index(;export_dir=".")
     end
 end
 
-function export_paths(notebook_paths::Vector{String}; export_dir=".", copy_to_temp_before_running=false, offer_binder=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing, kwargs...)
+function export_paths(notebook_paths::Vector{String}; export_dir=".", output_dir=".", copy_to_temp_before_running=false, offer_binder=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing, kwargs...)
     export_dir = Pluto.tamepath(export_dir)
 
     options = Pluto.Configuration.from_flat_kwargs(; kwargs...)
@@ -85,7 +85,7 @@ function export_paths(notebook_paths::Vector{String}; export_dir=".", copy_to_te
                 path * ".html"
             end
 
-            export_path = joinpath(export_dir, html_filename)
+            export_path = joinpath(output_dir, basename(html_filename))
             export_jl_path = joinpath(export_dir, path)
             mkpath(dirname(export_path))
 

--- a/src/Export.jl
+++ b/src/Export.jl
@@ -14,7 +14,7 @@ get(ENV, "GITHUB_ACTIONS", "false") == "true" && global_logger(GitHubActionsLogg
 
 myhash = base64encode ∘ sha256
 
-function github_action(; export_dir=".", output_dir=".", generate_default_index=false, offer_binder=false, copy_to_temp_before_running=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing, kwargs...)
+function github_action(; export_dir=".", output_dir=".", generate_default_index=true, offer_binder=false, copy_to_temp_before_running=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing, kwargs...)
     mkpath(export_dir)
 
     jlfiles = vcat(map(walkdir(".")) do (root, dirs, files)

--- a/src/Export.jl
+++ b/src/Export.jl
@@ -14,7 +14,7 @@ get(ENV, "GITHUB_ACTIONS", "false") == "true" && global_logger(GitHubActionsLogg
 
 myhash = base64encode ∘ sha256
 
-function github_action(; export_dir=".", output_dir=".", generate_default_index=false, offer_binder=false, copy_to_temp_before_running=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing)
+function github_action(; export_dir=".", output_dir=".", generate_default_index=false, offer_binder=false, copy_to_temp_before_running=false, disable_ui=true, bind_server_url=nothing, binder_url=nothing, kwargs...)
     mkpath(export_dir)
 
     jlfiles = vcat(map(walkdir(".")) do (root, dirs, files)
@@ -29,7 +29,7 @@ function github_action(; export_dir=".", output_dir=".", generate_default_index=
     notebookfiles = filter(jlfiles) do f
         readline(f) == "### A Pluto.jl notebook ###"
     end
-    export_paths(notebookfiles; export_dir=export_dir, output_dir=output_dir, copy_to_temp_before_running=copy_to_temp_before_running, offer_binder=offer_binder, disable_ui=disable_ui, bind_server_url=bind_server_url, binder_url=binder_url)
+    export_paths(notebookfiles; export_dir=export_dir, output_dir=output_dir, copy_to_temp_before_running=copy_to_temp_before_running, offer_binder=offer_binder, disable_ui=disable_ui, bind_server_url=bind_server_url, binder_url=binder_url, kwargs...)
 
     generate_default_index && create_default_index(;export_dir=export_dir)
 end
@@ -85,9 +85,11 @@ function export_paths(notebook_paths::Vector{String}; export_dir=".", output_dir
                 path * ".html"
             end
 
+            mkpath(output_dir)
+            @show output_dir
+            @show isdir(output_dir)
             export_path = joinpath(output_dir, basename(html_filename))
             export_jl_path = joinpath(export_dir, path)
-            mkpath(dirname(export_path))
 
 
             notebookfile_js = if offer_binder


### PR DESCRIPTION
This PR is about adding some kwargs to make the html generation easier to integrate with Documenter.

NOTE:

I tried deploying my own pluto notebook here: https://giggleliu.github.io/NiLang.jl/dev/notebooks/documentation.html
It looks pretty good. Thanks!

Following the example here: https://github.com/fonsp/disorganised-mess/blob/master/.github/workflows/ExportPluto.yaml
I made my script here:
https://github.com/GiggleLiu/NiLang.jl/blob/a205ae663e4a0790959e6118d076ff9c42e74a57/docs/make.jl#L56

Just generate the `html` to the build folder of Documenter, then one can just link to it in the index of the documentation.

