### PR TITLE
Fix create_sysimage call

### DIFF
--- a/docker/precompiled/create_sysimage.jl
+++ b/docker/precompiled/create_sysimage.jl
@@ -1,5 +1,5 @@
 using Pkg
-Pkg.add(["Pluto", "PlutoUI", "PackageCompiler"]) #"Plots", "Images", "ImageIO", "ImageMagick", 
+Pkg.add(["Pluto", "PlutoUI", "PackageCompiler"]) #"Plots", "Images", "ImageIO", "ImageMagick",
 
 using PackageCompiler
-create_sysimage([:Pluto, :PlutoUI]; precompile_execution_file="warmup.jl", replace_default=true, cpu_target = PackageCompiler.default_app_cpu_target())
+create_sysimage([:Pluto, :PlutoUI]; precompile_execution_file="warmup.jl", cpu_target = PackageCompiler.default_app_cpu_target(), sysimage_path="sys.so")


### PR DESCRIPTION
Hi

I wanted to build the `precompiled` Docker image locally and noticed it's no longer working because of changes in the `create_sysimage` function. I updated the code as best I can, but I'm very new to Julia.